### PR TITLE
Thread shutdown usage for MITO to properly end after completion

### DIFF
--- a/src/main/java/de/tum/bgu/msm/modules/travelTimeBudget/TravelTimeBudgetModule.java
+++ b/src/main/java/de/tum/bgu/msm/modules/travelTimeBudget/TravelTimeBudgetModule.java
@@ -54,6 +54,8 @@ public class TravelTimeBudgetModule extends Module {
             service.invokeAll(tasks);
         } catch (InterruptedException e) {
             e.printStackTrace();
+        } finally {
+        	service.shutdownNow();
         }
 
         logger.info("  Adjusting travel time budgets.");

--- a/src/main/java/de/tum/bgu/msm/modules/tripDistribution/TripDistribution.java
+++ b/src/main/java/de/tum/bgu/msm/modules/tripDistribution/TripDistribution.java
@@ -75,7 +75,7 @@ public final class TripDistribution extends Module {
         homeBasedTasks.add(HbeHbwDistribution.hbe(utilityMatrices.get(HBE), dataSet));
         executor.submitTasksAndWaitForCompletion(homeBasedTasks);
 
-
+        executor = ConcurrentExecutor.fixedPoolService(Purpose.values().length);
         List<Callable<Void>> nonHomeBasedTasks = new ArrayList<>();
         nonHomeBasedTasks.add(NhbwNhboDistribution.nhbw(utilityMatrices, dataSet));
         nonHomeBasedTasks.add(NhbwNhboDistribution.nhbo(utilityMatrices, dataSet));

--- a/src/main/java/de/tum/bgu/msm/util/concurrent/ConcurrentExecutor.java
+++ b/src/main/java/de/tum/bgu/msm/util/concurrent/ConcurrentExecutor.java
@@ -47,6 +47,8 @@ public class ConcurrentExecutor<T> {
             }).collect(Collectors.toList());
         } catch (Exception e) {
             throw new RuntimeException(e);
+        } finally {
+        	service.shutdownNow();
         }
     }
 
@@ -60,6 +62,8 @@ public class ConcurrentExecutor<T> {
             return result.get();
         } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);
+        } finally {
+        	service.shutdownNow();
         }
     }
 
@@ -68,6 +72,8 @@ public class ConcurrentExecutor<T> {
             return service.invokeAll(tasks);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
+        } finally {
+        	service.shutdownNow();
         }
     }
 }


### PR DESCRIPTION
Java did not end upon completion of MITO since a few threads were not closed. Added shutdown-function usage for all concurrent threading to ensure all threads are closed and Java can completely end after MITO.