### PR TITLE
read UAM xml data to generate skims in mito

### DIFF
--- a/src/main/java/de/tum/bgu/msm/MitoModel.java
+++ b/src/main/java/de/tum/bgu/msm/MitoModel.java
@@ -89,6 +89,10 @@ public final class MitoModel {
         dataSet.setTotalHandlingTimes(new UniformTotalHandlingTimes());
         new SkimsReader(dataSet).read();
         readAdditionalData();
+        UAMNetworkReader uamReader = new UAMNetworkReader(dataSet);
+        uamReader.read();
+        uamReader.printOutSampleForDebugging("./debugTimesUam.csv");
+
     }
 
     private void readAdditionalData() {

--- a/src/main/java/de/tum/bgu/msm/data/DataSet.java
+++ b/src/main/java/de/tum/bgu/msm/data/DataSet.java
@@ -7,6 +7,7 @@ import de.tum.bgu.msm.data.accessTimes.AccessAndEgressVariables;
 import de.tum.bgu.msm.data.travelDistances.TravelDistances;
 import de.tum.bgu.msm.data.travelTimes.TravelTimes;
 import de.tum.bgu.msm.data.waitingTimes.TotalHandlingTimes;
+import net.bhl.matsim.uam.infrastructure.UAMStation;
 import org.matsim.core.controler.Controler;
 
 import java.util.*;
@@ -47,6 +48,7 @@ public class DataSet {
     private EnumMap<Purpose, DoubleMatrix1D> durationMinuteCumProbByPurpose;
     private EnumMap<Purpose, DoubleMatrix1D> departureMinuteCumProbByPurpose;
     private Controler matsimControler;
+    private Map<UAMStation, MitoZone> stationToZoneMap;
 
     public TravelDistances getTravelDistancesAuto(){return this.travelDistancesAuto;}
 
@@ -278,5 +280,13 @@ public class DataSet {
 
     public void emptyTripSubsample() {
         tripSubsample = new LinkedHashMap<>();
+    }
+
+    public void setUAMStationAndZoneMap(Map<UAMStation, MitoZone> stationZoneMap) {
+        this.stationToZoneMap = stationZoneMap;
+    }
+
+    public Map<UAMStation, MitoZone> getStationToZoneMap() {
+        return stationToZoneMap;
     }
 }

--- a/src/main/java/de/tum/bgu/msm/data/MitoZone.java
+++ b/src/main/java/de/tum/bgu/msm/data/MitoZone.java
@@ -169,4 +169,7 @@ public class MitoZone implements Id, Location {
         return zoneId;
     }
 
+    public SimpleFeature getShapeFeature() {
+        return shapeFeature;
+    }
 }

--- a/src/main/java/de/tum/bgu/msm/io/input/readers/SkimsReader.java
+++ b/src/main/java/de/tum/bgu/msm/io/input/readers/SkimsReader.java
@@ -52,6 +52,7 @@ public class SkimsReader extends AbstractOmxReader {
         ((SkimTravelTimes) dataSet.getTravelTimes()).readSkim("train", Resources.INSTANCE.getString(Properties.TRAIN_TRAVEL_TIME_SKIM), "mat1", 1.);
 
 
+        //todo THIS needs to be removed when the class UAMNetowrkReader is finalized!!!
         //read uam distance and divide by speed (property). Add access and egress time and update this matrix in travel times
         IndexedDoubleMatrix2D flyingDistance_km =
                 AbstractOmxReader.readAndConvertToDoubleMatrix(Resources.INSTANCE.getString(Properties.UAM_SKIM),
@@ -65,6 +66,7 @@ public class SkimsReader extends AbstractOmxReader {
 
         IndexedDoubleMatrix2D uamTravelTime = new IndexedDoubleMatrix2D(dataSet.getZones().values(), dataSet.getZones().values());
 
+        //todo THIS needs to be removed when the class UAMNetowrkReader is finalized!!!
         for (int row : uamTravelTime.getRowLookupArray()) {
             for (int column : uamTravelTime.getColumnLookupArray()) {
                 if (flyingDistance_km.getIndexed(row, column) < 10000.) {
@@ -90,6 +92,8 @@ public class SkimsReader extends AbstractOmxReader {
     private void readAccessTimeSkims() {
         dataSet.getAccessAndEgressVariables().readSkim("transit", AccessAndEgressVariables.AccessVariable.ACCESS_T_MIN, Resources.INSTANCE.getString(Properties.PT_ACCESS_TIME_SKIM), "mat1", 1.);
 
+
+        //todo THIS needs to be removed when the class UAMNetowrkReader is finalized!!!
         dataSet.getAccessAndEgressVariables().readSkim("uam",
                 AccessAndEgressVariables.AccessVariable.ACCESS_T_MIN,
                 Resources.INSTANCE.getString(Properties.UAM_SKIM), "access_time", 1. / 60);
@@ -114,10 +118,12 @@ public class SkimsReader extends AbstractOmxReader {
                 }
             }
         }
+        //todo THIS needs to be removed when the class UAMNetowrkReader is finalized!!!
         //... and later set up within the access and egress data container
         dataSet.getAccessAndEgressVariables().setExternally(access_dist, "uam", AccessAndEgressVariables.AccessVariable.ACCESS_DIST_KM);
         dataSet.getAccessAndEgressVariables().setExternally(egress_dist, "uam", AccessAndEgressVariables.AccessVariable.EGRESS_DIST_KM);
 
+        //todo THIS needs to be removed when the class UAMNetowrkReader is finalized!!!
         //todo the vertiport zones should not be a double matrix!! Consider to implement it.
         dataSet.getAccessAndEgressVariables().readSkim("uam",
                 AccessAndEgressVariables.AccessVariable.ACCESS_VERTIPORT,
@@ -132,9 +138,11 @@ public class SkimsReader extends AbstractOmxReader {
         dataSet.setTravelDistancesAuto(new MatrixTravelDistances(distanceSkimAuto));
         IndexedDoubleMatrix2D distanceSkimNMT = AbstractOmxReader.readAndConvertToDoubleMatrix(Resources.INSTANCE.getString(Properties.NMT_TRAVEL_DISTANCE_SKIM), "distanceByDistance", 1. / 1000.);
         dataSet.setTravelDistancesNMT(new MatrixTravelDistances(distanceSkimNMT));
-        //todo temporally we read cost and in the mode choice scripts we divided by 5 to use it as distance. In the future, read directly flying distance
-        //read flying distance
 
+
+
+        //todo THIS needs to be removed when the class UAMNetowrkReader is finalized!!!
+        //read flying distance
         IndexedDoubleMatrix2D travelDistanceUAM = AbstractOmxReader.readAndConvertToDoubleMatrix(Resources.INSTANCE.getString(Properties.UAM_SKIM), "uam_dist", 1);
         dataSet.setFlyingDistanceUAM(new MatrixTravelDistances(travelDistanceUAM));
     }

--- a/src/main/java/de/tum/bgu/msm/io/input/readers/UAMNetworkReader.java
+++ b/src/main/java/de/tum/bgu/msm/io/input/readers/UAMNetworkReader.java
@@ -1,0 +1,290 @@
+package de.tum.bgu.msm.io.input.readers;
+
+import com.google.common.math.LongMath;
+import com.vividsolutions.jts.geom.*;
+import de.tum.bgu.msm.data.DataSet;
+import de.tum.bgu.msm.data.MitoZone;
+import de.tum.bgu.msm.data.accessTimes.AccessAndEgressVariables;
+import de.tum.bgu.msm.data.travelDistances.MatrixTravelDistances;
+import de.tum.bgu.msm.data.travelDistances.TravelDistances;
+import de.tum.bgu.msm.data.travelTimes.SkimTravelTimes;
+import de.tum.bgu.msm.data.travelTimes.TravelTimes;
+import de.tum.bgu.msm.resources.Properties;
+import de.tum.bgu.msm.resources.Resources;
+import de.tum.bgu.msm.util.MitoUtil;
+import de.tum.bgu.msm.util.matrices.IndexedDoubleMatrix2D;
+import net.bhl.matsim.uam.infrastructure.UAMStation;
+import net.bhl.matsim.uam.infrastructure.readers.UAMXMLReader;
+import org.apache.log4j.Logger;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.router.FastMultiNodeDijkstraFactory;
+import org.matsim.core.router.MultiNodePathCalculator;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.vehicles.EngineInformation;
+import org.matsim.vehicles.Vehicle;
+import org.matsim.vehicles.VehicleCapacity;
+import org.matsim.vehicles.VehicleType;
+import org.opengis.feature.simple.SimpleFeature;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Reads the MATSim uam files (network and station list)
+ */
+public class UAMNetworkReader {
+
+    private static final Logger logger = Logger.getLogger(UAMNetworkReader.class);
+    private final DataSet dataSet;
+    private final int TIME_OF_DAY_S = 8 * 60 * 60;
+    private final String ACCESS_MODE = "car";
+    private Network network;
+
+
+    public UAMNetworkReader(DataSet dataSet) {
+        this.dataSet = dataSet;
+    }
+
+    public void read() {
+
+        String networkFileName = Resources.INSTANCE.getString(Properties.MATSIM_NETWORK_FILE);
+
+        Config config = ConfigUtils.createConfig();
+        config.network().setInputFile(networkFileName);
+        Scenario scenario = ScenarioUtils.loadScenario(config);
+        this.network = scenario.getNetwork();
+        String uamStationAndVehicleFileName = Resources.INSTANCE.getString(Properties.UAM_VEHICLES);
+
+        UAMXMLReader uamxmlReader = new UAMXMLReader(network);
+        uamxmlReader.readFile(uamStationAndVehicleFileName);
+
+        Map<Id<UAMStation>, UAMStation> stationMap = uamxmlReader.getStations();
+
+        //map stations to zones
+        Map<UAMStation, MitoZone> stationZoneMap = new HashMap<>();
+
+        for (UAMStation station : stationMap.values()) {
+            for (MitoZone zone : dataSet.getZones().values()) {
+                SimpleFeature feature = zone.getShapeFeature();
+                MultiPolygon polygon = (MultiPolygon) feature.getDefaultGeometry();
+                Coord coord = station.getLocationLink().getFromNode().getCoord();
+                GeometryFactory factory = polygon.getFactory();
+                Point point = factory.createPoint(new Coordinate(coord.getX(), coord.getY()));
+                if (polygon.contains(point)) {
+                    stationZoneMap.put(station, zone);
+                }
+            }
+        }
+
+        dataSet.setUAMStationAndZoneMap(stationZoneMap);
+
+        //create matrices for the zones that have vertiports:
+        IndexedDoubleMatrix2D travelTimeUamAtServedZones = new IndexedDoubleMatrix2D(stationZoneMap.values(), stationZoneMap.values());
+        IndexedDoubleMatrix2D travelDistanceUamAtServedZones = new IndexedDoubleMatrix2D(stationZoneMap.values(), stationZoneMap.values());
+        //TODO maybe, we need to use the routing of the uam extension - the current version does
+        // calculates a beeline distance
+
+        for (UAMStation originStation : stationMap.values()) {
+            for (UAMStation destinationStation : stationMap.values()) {
+                if (!originStation.equals(destinationStation)) {
+                    Coord origCoord = originStation.getLocationLink().getFromNode().getCoord();
+                    Coord destCoord = destinationStation.getLocationLink().getFromNode().getCoord();
+                    double travelDistance_m = NetworkUtils.getEuclideanDistance(origCoord,destCoord);
+                    double travelTime_s = travelDistance_m / Resources.INSTANCE.getDouble(Properties.UAM_SPEED_KMH, 200) * 3.6;
+                    travelTime_s += originStation.getDefaultWaitTime() + originStation.getPreFlightTime() +
+                            destinationStation.getPostFlightTime();
+
+                    travelTimeUamAtServedZones.setIndexed(stationZoneMap.get(originStation).getId(),
+                            stationZoneMap.get(destinationStation).getId(),
+                            travelTime_s / 60);
+                    travelDistanceUamAtServedZones.setIndexed(stationZoneMap.get(originStation).getId(),
+                            stationZoneMap.get(destinationStation).getId(),
+                            travelDistance_m / 1000);
+                }
+            }
+        }
+        logger.info("The matrix is completed for zones served by UAM");
+
+        //Create matrices for all the zones of the model
+        TravelTimes travelTimes = dataSet.getTravelTimes();
+        TravelDistances travelDistancesAuto = dataSet.getTravelDistancesAuto();
+
+        IndexedDoubleMatrix2D travelTimeUam = new IndexedDoubleMatrix2D(dataSet.getZones().values(), dataSet.getZones().values());
+        IndexedDoubleMatrix2D accessVertiportUam = new IndexedDoubleMatrix2D(dataSet.getZones().values(), dataSet.getZones().values());
+        IndexedDoubleMatrix2D egressVertiportUam = new IndexedDoubleMatrix2D(dataSet.getZones().values(), dataSet.getZones().values());
+        IndexedDoubleMatrix2D accessDistanceUam = new IndexedDoubleMatrix2D(dataSet.getZones().values(), dataSet.getZones().values());
+        IndexedDoubleMatrix2D egressDistanceUam = new IndexedDoubleMatrix2D(dataSet.getZones().values(), dataSet.getZones().values());
+        IndexedDoubleMatrix2D accessTimeUam = new IndexedDoubleMatrix2D(dataSet.getZones().values(), dataSet.getZones().values());
+        IndexedDoubleMatrix2D egressTimeUam = new IndexedDoubleMatrix2D(dataSet.getZones().values(), dataSet.getZones().values());
+        IndexedDoubleMatrix2D travelDistanceUAM = new IndexedDoubleMatrix2D(dataSet.getZones().values(), dataSet.getZones().values());
+
+        int counter = 0;
+        for (MitoZone originZone : dataSet.getZones().values()) {
+            for (MitoZone destinationZone : dataSet.getZones().values()) {
+                counter++;
+                int origId = originZone.getId();
+                int destId = destinationZone.getId();
+                if (!originZone.equals(destinationZone)) {
+                    double minTravelTime = 10000;
+                    double carTravelTime = travelTimes.getTravelTime(originZone, destinationZone, TIME_OF_DAY_S, ACCESS_MODE);
+                    UAMStation accessStationChosen = null;
+                    UAMStation egressStationChosen = null;
+
+
+                    for (UAMStation accessStation : stationMap.values()) {
+                        for (UAMStation egressStation : stationMap.values()) {
+                            if (!accessStation.equals(egressStation)) {
+                                MitoZone accessZone = stationZoneMap.get(accessStation);
+                                MitoZone egressZone = stationZoneMap.get(egressStation);
+                                double travelTimeAtThisRoute = travelTimes.getTravelTime(originZone, accessZone, TIME_OF_DAY_S, ACCESS_MODE) +
+                                        travelTimeUamAtServedZones.getIndexed(accessZone.getId(), egressZone.getId()) +
+                                        travelTimes.getTravelTime(egressZone, destinationZone, TIME_OF_DAY_S, ACCESS_MODE);
+                                if (travelTimeAtThisRoute < minTravelTime) {
+                                    minTravelTime = travelTimeAtThisRoute;
+                                    accessStationChosen = accessStation;
+                                    egressStationChosen = egressStation;
+                                }
+                            }
+                        }
+                    }
+                    MitoZone accessZone = stationZoneMap.get(accessStationChosen);
+                    MitoZone egressZone = stationZoneMap.get(egressStationChosen);
+                    if (minTravelTime < carTravelTime) {
+                        travelTimeUam.setIndexed(origId, destId, minTravelTime);
+
+                        accessVertiportUam.setIndexed(origId,
+                                destId,
+                                accessZone.getId());
+                        egressVertiportUam.setIndexed(origId,
+                                destId,
+                                egressZone.getId());
+
+                        accessTimeUam.setIndexed(origId,
+                                destId,
+                                travelTimes.getTravelTime(originZone, accessZone, TIME_OF_DAY_S, ACCESS_MODE));
+                        egressTimeUam.setIndexed(origId,
+                                destId,
+                                travelTimes.getTravelTime(egressZone, destinationZone, TIME_OF_DAY_S, ACCESS_MODE));
+
+                        accessDistanceUam.setIndexed(origId,
+                                destId,
+                                travelDistancesAuto.getTravelDistance(origId, accessZone.getId()));
+                        egressDistanceUam.setIndexed(origId,
+                                destId,
+                                travelDistancesAuto.getTravelDistance(egressZone.getId(), destId));
+
+                        travelDistanceUAM.setIndexed(origId,
+                                destId,
+                                travelDistanceUamAtServedZones.getIndexed(accessZone.getId(), egressZone.getId()));
+
+                    } else {
+                        travelTimeUam.setIndexed(origId, destId, 10000.);
+                        accessVertiportUam.setIndexed(origId, destId, 10000);
+                        egressVertiportUam.setIndexed(origId, destId, 10000);
+                        accessTimeUam.setIndexed(origId, destId, 10000);
+                        egressTimeUam.setIndexed(origId, destId, 10000);
+                        accessDistanceUam.setIndexed(origId, destId, 10000);
+                        egressDistanceUam.setIndexed(origId, destId, 10000);
+                        travelDistanceUAM.setIndexed(origId, destId, 10000);
+                    }
+                } else {
+                    travelTimeUam.setIndexed(origId, destId, 10000.);
+                    accessVertiportUam.setIndexed(origId, destId, 10000);
+                    egressVertiportUam.setIndexed(origId, destId, 10000);
+                    accessTimeUam.setIndexed(origId, destId, 10000);
+                    egressTimeUam.setIndexed(origId, destId, 10000);
+                    accessDistanceUam.setIndexed(origId, destId, 10000);
+                    egressDistanceUam.setIndexed(origId, destId, 10000);
+                    travelDistanceUAM.setIndexed(origId, destId, 10000);
+                }
+                if (LongMath.isPowerOfTwo(counter)) {
+                    logger.info("Completed " + counter + " origin-destination pairs");
+                }
+            }
+        }
+        logger.info("The matrix is completed for all zones");
+
+        //finnally, store the information in the respective containers
+        ((SkimTravelTimes) dataSet.getTravelTimes()).updateSkimMatrix(travelTimeUam, "uam");
+
+
+        dataSet.getAccessAndEgressVariables().
+                setExternally(accessVertiportUam, "uam", AccessAndEgressVariables.AccessVariable.ACCESS_VERTIPORT);
+        dataSet.getAccessAndEgressVariables().
+                setExternally(egressVertiportUam, "uam", AccessAndEgressVariables.AccessVariable.EGRESS_VERTIPORT);
+
+        dataSet.getAccessAndEgressVariables().
+                setExternally(accessTimeUam, "uam", AccessAndEgressVariables.AccessVariable.ACCESS_T_MIN);
+        dataSet.getAccessAndEgressVariables().
+                setExternally(egressTimeUam, "uam", AccessAndEgressVariables.AccessVariable.EGRESS_T_MIN);
+
+        dataSet.getAccessAndEgressVariables().
+                setExternally(accessDistanceUam, "uam", AccessAndEgressVariables.AccessVariable.ACCESS_DIST_KM);
+        dataSet.getAccessAndEgressVariables().
+                setExternally(egressDistanceUam, "uam", AccessAndEgressVariables.AccessVariable.EGRESS_DIST_KM);
+
+        dataSet.setFlyingDistanceUAM(new MatrixTravelDistances(travelDistanceUAM));
+
+    }
+
+    public void printOutSampleForDebugging(String fileName) {
+        try {
+            PrintWriter pw = new PrintWriter(new File(fileName));
+            pw.println("origin,destination,originVertiport,destVertiport,time,accessTime,egressTime,flyingDistance,accessDistance,egressDistance,timeCar,distanceCar");
+
+            for (MitoZone originZone : dataSet.getZones().values()) {
+                for (MitoZone destinationZone : dataSet.getZones().values()) {
+                    if (originZone.getId() == 1659 || originZone.getId() == 4445 || originZone.getId() == 1) {
+                        pw.print(originZone.getId());
+                        pw.print(",");
+                        pw.print(destinationZone.getId());
+                        pw.print(",");
+                        pw.print(dataSet.getAccessAndEgressVariables().getAccessVariable(originZone, destinationZone, "uam", AccessAndEgressVariables.AccessVariable.ACCESS_VERTIPORT));
+                        pw.print(",");
+                        pw.print(dataSet.getAccessAndEgressVariables().getAccessVariable(originZone, destinationZone, "uam", AccessAndEgressVariables.AccessVariable.EGRESS_VERTIPORT));
+                        pw.print(",");
+                        pw.print(dataSet.getTravelTimes().getTravelTime(originZone, destinationZone, TIME_OF_DAY_S, "uam"));
+                        pw.print(",");
+                        pw.print(dataSet.getAccessAndEgressVariables().getAccessVariable(originZone, destinationZone, "uam", AccessAndEgressVariables.AccessVariable.ACCESS_T_MIN));
+                        pw.print(",");
+                        pw.print(dataSet.getAccessAndEgressVariables().getAccessVariable(originZone, destinationZone, "uam", AccessAndEgressVariables.AccessVariable.EGRESS_T_MIN));
+                        pw.print(",");
+                        pw.print(dataSet.getFlyingDistanceUAM().getTravelDistance(originZone.getId(), destinationZone.getId()));
+                        pw.print(",");
+                        pw.print(dataSet.getAccessAndEgressVariables().getAccessVariable(originZone, destinationZone, "uam", AccessAndEgressVariables.AccessVariable.ACCESS_DIST_KM));
+                        pw.print(",");
+                        pw.print(dataSet.getAccessAndEgressVariables().getAccessVariable(originZone, destinationZone, "uam", AccessAndEgressVariables.AccessVariable.EGRESS_DIST_KM));
+                        pw.print(",");
+                        pw.print(dataSet.getTravelTimes().getTravelTime(originZone, destinationZone, TIME_OF_DAY_S, "car"));
+                        pw.print(",");
+                        pw.print(dataSet.getTravelDistancesAuto().getTravelDistance(originZone.getId(), destinationZone.getId()));
+                        pw.println();
+                    }
+
+                }
+            }
+
+            pw.close();
+
+
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+}


### PR DESCRIPTION
The UAM xml data is now read in mito and travel time matrices are created, including access vertiports and access times. 

The travel time by UAM on the air is still simplified to beeline distance divided by speed. We need to use the routing module of the uam extentsion. 
