### PR TITLE
Correction to trip gen hurdle

### DIFF
--- a/src/main/java/de/tum/bgu/msm/modules/tripGeneration/TripsByPurposeGeneratorHurdleModel.java
+++ b/src/main/java/de/tum/bgu/msm/modules/tripGeneration/TripsByPurposeGeneratorHurdleModel.java
@@ -73,7 +73,7 @@ public class TripsByPurposeGeneratorHurdleModel extends RandomizableConcurrentFu
 
     private double getUtilityTravelBinaryLogit(MitoHousehold hh) {
         double utilityTravel = 0.;
-        int size = hh.getHhSize();
+        int size = Math.min(hh.getHhSize(),5);
         switch (size) {
             case 1:
                 utilityTravel += binLogCoef.get("size_1");


### PR DESCRIPTION
Corrects the trip generation hurdle model so the size_5 coefficient is applied for all households greater than or equal to 5